### PR TITLE
Add default to request_options

### DIFF
--- a/storedsafe/__init__.py
+++ b/storedsafe/__init__.py
@@ -52,7 +52,7 @@ class StoredSafe:
         if self.apikey is None:
             raise ApikeyUndefinedException()
 
-    def __headers(self, requests_options, token=True):
+    def __headers(self, requests_options={}, token=True):
         """Create the required headers for requests to the StoredSafe API and merge with options."""
         headers = {
             **self.requests_options.get('headers', {}),


### PR DESCRIPTION
When accessing __headers() directly without explicit setting request_options the function will fail. By defaulting to an empty dict we circumvent this.